### PR TITLE
Fix CI following python 3.8 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3-slim
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y gcc
+
 COPY . ./
 
 RUN python setup.py install


### PR DESCRIPTION
there are some python deps that are not pre-compiled for python 3.8 yet, so install fails because it can't build them from source without gcc.